### PR TITLE
crossref pub search

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ APIs used to retrieve metadata:
   * [Dimensions](https://docs.dimensions.ai/dsl/api.html)
   * [RePEc](https://ideas.repec.org/api.html)
   * [SSRN](https://www.ssrn.com/)
+  * [Crossref](https://www.crossref.org/services/metadata-delivery/)
+  * [PubMed](https://www.ncbi.nlm.nih.gov/books/NBK25501/)
 
 See `docs/enrich_pubs.ipynb` for example API usage to pull the
 federated metadata for a publication.
@@ -123,7 +125,7 @@ nose2 -v --pretty-assert
 
  * parse HTML-embedded metadata from the web pages for PMC/Pubmed, NIH, etc.
  * [Scholexplorer](http://scholexplorer.openaire.eu/#/)
- * [DataCite and Crossref integrations](https://github.com/NYU-CI/RCApi/issues/8)
+ * [DataCite integration](https://github.com/NYU-CI/RCApi/issues/8)
  * [PapersWithCode](https://paperswithcode.com/?ref=semscholar)
  * [Springer](https://github.com/srand525/search_springer/blob/master/SpringerFetch.py)
 
@@ -142,4 +144,3 @@ plus many thanks for the inspiring *2019 Rich Context Workshop* notes by
 and guidance from
 [@claytonrsh](https://github.com/claytonrsh),
 [@Juliaingridlane](https://github.com/Juliaingridlane).
-

--- a/example.py
+++ b/example.py
@@ -4,7 +4,6 @@
 from richcontext import scholapi as rc_scholapi
 import logging
 import pprint
-import requests
 import sys
 
 
@@ -21,8 +20,8 @@ if __name__ == "__main__":
     schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg", logger=None)
 
     # search parameters for example publications
-    title = "Deal or no deal? The prevalence and nutritional quality of price promotions among U.S. food and beverage purchases."
     doi = "10.1016/j.appet.2017.07.006"
+    title = "Deal or no deal? The prevalence and nutritional quality of price promotions among U.S. food and beverage purchases."
 
     # run it...
     meta = schol.europepmc.title_search(title)

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,3 +2,5 @@ beautifulsoup4 >= 4.6.3
 dimcli >= 0.6.1
 requests >= 2.22.0
 selenium >= 3.141.0
+biopython >= 1.75
+xmltodict >= 0.12.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,8 @@
 beautifulsoup4 >= 4.6.3
+biopython >= 1.75
+crossref-commons >= 0.0.6
 dimcli >= 0.6.1
 requests >= 2.22.0
+requests-cache >= 0.5.2
 selenium >= 3.141.0
-biopython >= 1.75
 xmltodict >= 0.12.0

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -434,14 +434,59 @@ class ScholInfra_CrossRef (ScholInfra):
         
         t0 = time.time()
         url = self.get_api_url(identifier)
-        print(url)
         
         meta = crossref_commons.retrieval.get_publication_as_json(url)
-        print(meta)
+        
+        t1 = time.time()
+        self.elapsed_time = (t1 - t0) * 1000.0
+        
         if meta:
             return meta
         else:
             return None
+
+    def title_search (self, title):
+        """
+        parse metadata returned from crossref API given a title
+        """
+        
+        t0 = time.time()
+        url = "https://api.crossref.org/works?query.bibliographic={}".format(title)
+        response = requests.get(url).text
+
+        json_response = json.loads(response)
+
+        results = json_response["message"]["items"]
+
+        t1 = time.time()
+        self.elapsed_time = (t1 - t0) * 1000.0
+
+        if results:
+            return results
+        else:
+            return None
+
+
+
+    def full_text_search (self, search_term):
+        """
+        search CrossRef using term e.g. NHANES - note, crossref doesn't support exact string matching for multi-term strings. see https://github.com/CrossRef/rest-api-doc/issues/143
+        """
+        t0 = time.time()
+
+        url = "https://api.crossref.org/works?query=%22{}%22/type/journal-article&rows=1000".format(search_term)
+
+        response = requests.get(url).text
+
+        json_response = json.loads(response)
+
+        search_results = json_response["message"]
+
+        t1 = time.time()
+        self.elapsed_time = (t1 - t0) * 1000.0
+
+        return search_results
+
 
 ######################################################################
 ## federated API access

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -1,26 +1,28 @@
 #!/usr/bin/env python
 # encoding: utf-8
 
+from Bio import Entrez
 from bs4 import BeautifulSoup
 from collections import OrderedDict
-import crossref_commons.retrieval
-from Bio import Entrez
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
 from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.support.ui import WebDriverWait
 import configparser
+import crossref_commons.retrieval
 import dimcli
 import json
 import logging
 import re
 import requests
+import requests_cache
 import sys
 import time
 import traceback
 import urllib.parse
 import xmltodict
+
 
 class ScholInfra:
     """
@@ -68,6 +70,14 @@ class ScholInfra:
         return self.api_url.format(*args)
 
 
+    def mark_time (self, t0):
+        """
+        mark the elapsed time since the start of the API access method
+        """
+        t1 = time.time()
+        self.elapsed_time = (t1 - t0) * 1000.0
+
+
 class ScholInfra_EuropePMC (ScholInfra):
     """
     https://europepmc.org/RestfulWebService
@@ -104,10 +114,12 @@ class ScholInfra_EuropePMC (ScholInfra):
                 if self.get_xml_node_value(result, "haspdf") == "Y":
                     meta["pdf"] = "http://europepmc.org/articles/{}?pdf=render".format(meta["pmcid"])
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+        self.mark_time(t0)
 
-        return meta
+        if len(meta) > 0:
+            return meta
+        else:
+            return None
 
 
 class ScholInfra_OpenAIRE (ScholInfra):
@@ -137,12 +149,12 @@ class ScholInfra_OpenAIRE (ScholInfra):
                 meta["url"] = self.get_xml_node_value(result, "url")
                 meta["authors"] = [a.text for a in result.find_all("creator")]
                 meta["open"] = len(result.find_all("bestaccessright",  {"classid": "OPEN"})) > 0
-                break
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+                self.mark_time(t0)
+                return meta
 
-        return meta
+        self.mark_time(t0)
+        return None
 
 
 class ScholInfra_SemanticScholar (ScholInfra):
@@ -159,10 +171,12 @@ class ScholInfra_SemanticScholar (ScholInfra):
         url = self.get_api_url(identifier)
         meta = json.loads(requests.get(url).text)
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+        self.mark_time(t0)
 
-        return meta
+        if meta and len(meta) > 0:
+            return meta
+        else:
+            return None
 
 
 class ScholInfra_Unpaywall (ScholInfra):
@@ -181,10 +195,12 @@ class ScholInfra_Unpaywall (ScholInfra):
         url = self.get_api_url(identifier, email)
         meta = json.loads(requests.get(url).text)
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+        self.mark_time(t0)
 
-        return meta
+        if meta and len(meta) > 0:
+            return meta
+        else:
+            return None
 
 
 class ScholInfra_dissemin (ScholInfra):
@@ -201,10 +217,12 @@ class ScholInfra_dissemin (ScholInfra):
         url = self.get_api_url(identifier)
         meta = json.loads(requests.get(url).text)
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+        self.mark_time(t0)
 
-        return meta
+        if meta and len(meta) > 0:
+            return meta
+        else:
+            return None
 
 
 class ScholInfra_Dimensions (ScholInfra):
@@ -244,11 +262,10 @@ class ScholInfra_Dimensions (ScholInfra):
                 if self.parent.logger:
                     self.parent.logger.debug(meta)
 
-                t1 = time.time()
-                self.elapsed_time = (t1 - t0) * 1000.0
-
+                self.mark_time(t0)
                 return meta
 
+        self.mark_time(t0)
         return None
 
 
@@ -260,11 +277,10 @@ class ScholInfra_Dimensions (ScholInfra):
 
         query = 'search publications in full_data for "\\"{}\\"" return publications[doi+title+journal]'.format(search_term)
         response = self.run_query(query)
+        search_results = response.publications
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-
-        return response.publications
+        self.mark_time(t0)
+        return search_results
 
 
 class ScholInfra_RePEc (ScholInfra):
@@ -303,16 +319,12 @@ class ScholInfra_RePEc (ScholInfra):
                 self.parent.logger.debug(li)
 
             # TODO: can we perform a title search here?
-
             handle = li.find("i").get_text()
-
-            t1 = time.time()
-            self.elapsed_time = (t1 - t0) * 1000.0
+            self.mark_time(t0)
 
             return handle
 
-        # otherwise...
-        self.elapsed_time = 0.0
+        self.mark_time(t0)
         return None
 
 
@@ -327,15 +339,12 @@ class ScholInfra_RePEc (ScholInfra):
             url = self.get_api_url(token, handle)
             meta = json.loads(requests.get(url).text)
 
-            t1 = time.time()
-            self.elapsed_time = (t1 - t0) * 1000.0
-
+            self.mark_time(t0)
             return meta
-
         except:
-            self.elapsed_time = 0.0
             print(traceback.format_exc())
             print("ERROR: {}".format(handle))
+            self.mark_time(t0)
             return None
 
 
@@ -369,10 +378,12 @@ class ScholInfra_SSRN (ScholInfra):
         authors = [a["content"] for a in auth_list]
         meta["authors"] = authors
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
+        self.mark_time(t0)
 
-        return meta
+        if len(meta) > 0:
+            return meta
+        else:
+            return None
     
 
     def publication_lookup (self, identifier):
@@ -384,11 +395,10 @@ class ScholInfra_SSRN (ScholInfra):
 
         if "ssrn" in url:    
             meta = self.url_lookup(url)
-
-            t1 = time.time()
-            self.elapsed_time = (t1 - t0) * 1000.0
+            self.mark_time(t0)
             return meta
         else:
+            self.mark_time(t0)
             return None
 
 
@@ -418,74 +428,74 @@ class ScholInfra_SSRN (ScholInfra):
         browser.quit()
 
         meta = self.url_lookup(url)
+        self.mark_time(t0)
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-
-        return meta
-
-
-
-class ScholInfra_CrossRef (ScholInfra):
-
-    def publication_lookup (self, identifier):
-        """
-        parse metadata returned from crossref API given a DOI
-        """
-        
-        t0 = time.time()
-        url = self.get_api_url(identifier)
-        
-        meta = crossref_commons.retrieval.get_publication_as_json(url)
-        
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-        
-        if meta:
+        if meta and len(meta) > 0:
             return meta
         else:
             return None
 
-    def title_search (self, title):
+
+class ScholInfra_Crossref (ScholInfra):
+
+    def publication_lookup (self, identifier):
         """
-        parse metadata returned from crossref API given a title
+        parse metadata returned from Crossref API given a DOI
         """
-        
         t0 = time.time()
-        url = "https://api.crossref.org/works?query.bibliographic={}".format(title)
-        response = requests.get(url).text
 
-        json_response = json.loads(response)
-
-        results = json_response["message"]["items"]
-
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-
-        if results:
-            return results
+        meta = crossref_commons.retrieval.get_publication_as_json(identifier)
+        self.mark_time(t0)
+        
+        if meta and len(meta) > 0:
+            return meta
         else:
             return None
 
 
-
-    def full_text_search (self, search_term):
+    def title_search (self, title):
         """
-        search CrossRef using term e.g. NHANES - note, crossref doesn't support exact string matching for multi-term strings. see https://github.com/CrossRef/rest-api-doc/issues/143
+        parse metadata returned from Crossref API given a title
         """
         t0 = time.time()
 
-        url = "https://api.crossref.org/works?query=%22{}%22/type/journal-article&rows=1000".format(search_term)
+        query = "query.bibliographic={}".format(urllib.parse.quote(title))
+        url = self.get_api_url(query)
 
         response = requests.get(url).text
-
         json_response = json.loads(response)
 
+        meta = json_response["message"]["items"][0]
+        result_title = meta["title"][0]
+
+        if self.title_match(title, result_title):
+            if self.parent.logger:
+                self.parent.logger.debug(meta)
+
+            self.mark_time(t0)
+            return meta
+
+        self.mark_time(t0)
+        return None
+
+
+    def full_text_search (self, search_term):
+        """
+        search the Crossref API using a given term e.g. NHANES. 
+        Note that Crossref doesn't support exact string matching 
+        for multiple terms within strings.
+        See https://github.com/CrossRef/rest-api-doc/issues/143
+        """
+        t0 = time.time()
+
+        query = "query=%22{}%22/type/journal-article&rows=1000".format(urllib.parse.quote(search_term))
+        url = self.get_api_url(query)
+
+        response = requests.get(url).text
+        json_response = json.loads(response)
         search_results = json_response["message"]
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-
+        self.mark_time(t0)
         return search_results
 
 
@@ -498,22 +508,36 @@ class ScholInfra_PubMed (ScholInfra):
         t0 = time.time()
         
         Entrez.email = self.parent.config["DEFAULT"]["email"]
-        
-        handle = Entrez.read(Entrez.esearch(db="pubmed", retmax=100, term="\"{}\"".format(title),field = "title",retmode = "xml"))
+
+        handle = Entrez.read(Entrez.esearch(
+                db="pubmed",
+                retmax=100,
+                term="\"{}\"".format(title),
+                field = "title",
+                retmode = "xml"
+                ))
         
         search_id = handle["IdList"][0]
         
-        fetch_result = Entrez.efetch(db="pubmed", id=search_id,retmode = "xml")
-
+        fetch_result = Entrez.efetch(db="pubmed", id=search_id, retmode="xml")
         data = fetch_result.read()
         fetch_result.close()
 
         xml = xmltodict.parse(data)
         meta = json.loads(json.dumps(xml))
+        meta = meta["PubmedArticleSet"]["PubmedArticle"]
 
-        t1 = time.time()
-        self.elapsed_time = (t1 - t0) * 1000.0
-        return meta
+        result_title = meta["MedlineCitation"]["Article"]["ArticleTitle"]
+
+        if self.title_match(title, result_title):
+            self.mark_time(t0)
+
+            if meta and len(meta) > 0:
+                return meta
+
+        self.mark_time(t0)
+        return None
+
 
 ######################################################################
 ## federated API access
@@ -521,7 +545,7 @@ class ScholInfra_PubMed (ScholInfra):
 class ScholInfraAPI:
     """
     API integrations for federating metadata lookup across multiple
-    scholarly infrastructure providers
+    discovery service APIs from scholarly infrastructure providers
     """
 
     def __init__ (self, config_file="rc.cfg", logger=None):
@@ -529,10 +553,13 @@ class ScholInfraAPI:
         self.config.read(config_file)
         self.logger = logger
 
-        self.crossref = ScholInfra_CrossRef(
+        # other initializations 
+        requests_cache.install_cache("richcontext")
+
+        self.crossref = ScholInfra_Crossref(
             parent=self,
-            name="CrossRef",
-            api_url ="https://doi.org/{}"
+            name="Crossref",
+            api_url ="https://api.crossref.org/works?{}"
             )
         
         self.europepmc = ScholInfra_EuropePMC(
@@ -546,7 +573,6 @@ class ScholInfraAPI:
             name="OpenAIRE",
             api_url="http://api.openaire.eu/search/publications?title={}"
             )
-
 
         self.pubmed = ScholInfra_PubMed(
             parent=self,
@@ -588,9 +614,6 @@ class ScholInfraAPI:
             name="SSRN",
             api_url ="https://doi.org/{}"
             )
-
-       
-
 
 
 ######################################################################

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -431,9 +431,7 @@ class ScholInfra_CrossRef (ScholInfra):
         """
         parse metadata returned from crossref API given a DOI
         """
-        CR_API_AGENT=self.parent.config["DEFAULT"]["CR_API_AGENT"],
-        CR_API_MAILTO=self.parent.config["DEFAULT"]["CR_API_MAILTO"],
-
+        
         t0 = time.time()
         url = self.get_api_url(identifier)
         print(url)

--- a/richcontext/scholapi/scholapi.py
+++ b/richcontext/scholapi/scholapi.py
@@ -3,6 +3,7 @@
 
 from bs4 import BeautifulSoup
 from collections import OrderedDict
+import crossref_commons.retrieval
 from selenium import webdriver
 from selenium.webdriver.common.by import By
 from selenium.webdriver.common.keys import Keys
@@ -423,6 +424,27 @@ class ScholInfra_SSRN (ScholInfra):
         return meta
 
 
+
+class ScholInfra_CrossRef (ScholInfra):
+
+    def publication_lookup (self, identifier):
+        """
+        parse metadata returned from crossref API given a DOI
+        """
+        CR_API_AGENT=self.parent.config["DEFAULT"]["CR_API_AGENT"],
+        CR_API_MAILTO=self.parent.config["DEFAULT"]["CR_API_MAILTO"],
+
+        t0 = time.time()
+        url = self.get_api_url(identifier)
+        print(url)
+        
+        meta = crossref_commons.retrieval.get_publication_as_json(url)
+        print(meta)
+        if meta:
+            return meta
+        else:
+            return None
+
 ######################################################################
 ## federated API access
 
@@ -482,6 +504,12 @@ class ScholInfraAPI:
         self.ssrn = ScholInfra_SSRN(
             parent=self,
             name="SSRN",
+            api_url ="https://doi.org/{}"
+            )
+
+        self.crossref = ScholInfra_CrossRef(
+            parent=self,
+            name="CrossRef",
             api_url ="https://doi.org/{}"
             )
 

--- a/test.py
+++ b/test.py
@@ -7,33 +7,6 @@ import unittest
    
 class TestOpenAPIs (unittest.TestCase):
 
-    def test_crossref_publication_lookup (self):
-        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
-        doi = "10.1503/cmaj.170880"
-
-        meta = schol.crossref.publication_lookup(doi)
-
-        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
-        self.assertTrue(meta["URL"] == "http://dx.doi.org/10.1503/cmaj.170880")
-    
-    def test_crossref_fulltext_search (self):
-        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
-        search_term = "NHANES"
-
-        search_results = schol.crossref.full_text_search(search_term)
-
-        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
-        self.assertTrue(search_results["total-results"] >= 884000)
-
-    def test_crossref_title_search (self):
-        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
-        title = "Supply-Side Subsidies to Improve Food Access and Dietary Outcomes: Evidence from the New Markets Tax Credit"
-
-        results = schol.crossref.title_search(title)
-
-        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
-        self.assertTrue(results[0]["title"][0].lower() == title.lower())
-
     def test_europepmc_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         title = "Zebrafish models: Gaining insight into purinergic signaling and neurological disorders"
@@ -41,6 +14,7 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.europepmc.elapsed_time, schol.europepmc.name))
         self.assertTrue(repr(meta) == "OrderedDict([('doi', '10.1016/j.pnpbp.2019.109770'), ('pmcid', None), ('journal', 'Prog Neuropsychopharmacol Biol Psychiatry'), ('authors', ['Nabinger DD', 'Altenhofen S', 'Bonan CD.'])])")
+
 
     def test_openaire_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
@@ -50,6 +24,37 @@ class TestOpenAPIs (unittest.TestCase):
         print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
         self.assertTrue(repr(meta) == "OrderedDict([('url', 'https://europepmc.org/articles/PMC5574185/'), ('authors', ['Taillie, Lindsey Smith', 'Ng, Shu Wen', 'Xue, Ya', 'Harding, Matthew']), ('open', True)])")
 
+
+    def test_crossref_publication_lookup (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        doi = "10.1503/cmaj.170880"
+
+        meta = schol.crossref.publication_lookup(doi)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(meta["URL"] == "http://dx.doi.org/10.1503/cmaj.170880")
+
+
+    def test_crossref_title_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        title = "Supply-Side Subsidies to Improve Food Access and Dietary Outcomes: Evidence from the New Markets Tax Credit"
+
+        meta = schol.crossref.title_search(title)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(meta["URL"] == "http://dx.doi.org/10.1177/0042098017740285")
+
+
+    def test_crossref_fulltext_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        search_term = "NHANES"
+
+        search_results = schol.crossref.full_text_search(search_term)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(search_results["total-results"] >= 884000)
+
+
     def test_pubmed_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         title = "Climate-change-driven accelerated sea-level rise detected in the altimeter era"
@@ -57,7 +62,7 @@ class TestOpenAPIs (unittest.TestCase):
         meta = schol.pubmed.title_search(title)
 
         print("\ntime: {:.3f} ms - {}".format(schol.pubmed.elapsed_time, schol.pubmed.name))
-        self.assertTrue(meta["PubmedArticleSet"]["PubmedArticle"]["MedlineCitation"]["PMID"]["#text"] == "29440401")
+        self.assertTrue(meta["MedlineCitation"]["PMID"]["#text"] == "29440401")
 
 
     def test_semantic_publication_lookup (self):

--- a/test.py
+++ b/test.py
@@ -34,8 +34,6 @@ class TestOpenAPIs (unittest.TestCase):
         print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
         self.assertTrue(results[0]["title"][0].lower() == title.lower())
 
-
-
     def test_europepmc_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         title = "Zebrafish models: Gaining insight into purinergic signaling and neurological disorders"
@@ -51,6 +49,15 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.openaire.elapsed_time, schol.openaire.name))
         self.assertTrue(repr(meta) == "OrderedDict([('url', 'https://europepmc.org/articles/PMC5574185/'), ('authors', ['Taillie, Lindsey Smith', 'Ng, Shu Wen', 'Xue, Ya', 'Harding, Matthew']), ('open', True)])")
+
+    def test_pubmed_title_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        title = "Climate-change-driven accelerated sea-level rise detected in the altimeter era"
+
+        meta = schol.pubmed.title_search(title)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.pubmed.elapsed_time, schol.pubmed.name))
+        self.assertTrue(meta["PubmedArticleSet"]["PubmedArticle"]["MedlineCitation"]["PMID"]["#text"] == "29440401")
 
 
     def test_semantic_publication_lookup (self):

--- a/test.py
+++ b/test.py
@@ -7,6 +7,15 @@ import unittest
    
 class TestOpenAPIs (unittest.TestCase):
 
+    def test_crossref_publication_lookup (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        doi = "10.1503/cmaj.170880"
+
+        meta = schol.crossref.publication_lookup(doi)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(meta["URL"] == "http://dx.doi.org/10.1503/cmaj.170880")
+
     def test_europepmc_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
         title = "Zebrafish models: Gaining insight into purinergic signaling and neurological disorders"
@@ -14,7 +23,6 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.europepmc.elapsed_time, schol.europepmc.name))
         self.assertTrue(repr(meta) == "OrderedDict([('doi', '10.1016/j.pnpbp.2019.109770'), ('pmcid', None), ('journal', 'Prog Neuropsychopharmacol Biol Psychiatry'), ('authors', ['Nabinger DD', 'Altenhofen S', 'Bonan CD.'])])")
-
 
     def test_openaire_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")

--- a/test.py
+++ b/test.py
@@ -15,6 +15,26 @@ class TestOpenAPIs (unittest.TestCase):
 
         print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
         self.assertTrue(meta["URL"] == "http://dx.doi.org/10.1503/cmaj.170880")
+    
+    def test_crossref_fulltext_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        search_term = "NHANES"
+
+        search_results = schol.crossref.full_text_search(search_term)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(search_results["total-results"] >= 884000)
+
+    def test_crossref_title_search (self):
+        schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")
+        title = "Supply-Side Subsidies to Improve Food Access and Dietary Outcomes: Evidence from the New Markets Tax Credit"
+
+        results = schol.crossref.title_search(title)
+
+        print("\ntime: {:.3f} ms - {}".format(schol.crossref.elapsed_time, schol.crossref.name))
+        self.assertTrue(results[0]["title"][0].lower() == title.lower())
+
+
 
     def test_europepmc_title_search (self):
         schol = rc_scholapi.ScholInfraAPI(config_file="rc.cfg")


### PR DESCRIPTION
added api calls for crossref for:
publication lookup (doi as input)
title search (string as input)
full text search (string as input)

Note for the last two, CrossRef [doesn't support exact string matches](https://github.com/CrossRef/rest-api-doc/issues/143), so using full text search to generate potential linkages for validation for datasets that have multi-term strings may not be, on it's own, a good way to get linkages because there will be many results.